### PR TITLE
Return distance along the path from function 'action'

### DIFF
--- a/src/pyneb/utilities.py
+++ b/src/pyneb/utilities.py
@@ -113,8 +113,7 @@ class TargetFunctions:
         dist = np.core.umath.clip(dist,0,dist.max())
         # dist = dist.clip(0)
         actOut = np.sum(np.sqrt(2*dist*potArr[1:]))
-        
-        return actOut, potArr, massArr
+        return actOut, potArr, massArr, dist
 
     @staticmethod
     def _term_in_action_sum(points,potential,masses=None):

--- a/src/pyneb/utilities.py
+++ b/src/pyneb/utilities.py
@@ -39,7 +39,7 @@ class TargetFunctions:
     :Maintainer: Daniel
     """
     @staticmethod
-    def action(path,potential,masses=None):
+    def action(path,potential,masses=None, get_dist=False):
         """
         The standard action functional
 
@@ -113,7 +113,10 @@ class TargetFunctions:
         dist = np.core.umath.clip(dist,0,dist.max())
         # dist = dist.clip(0)
         actOut = np.sum(np.sqrt(2*dist*potArr[1:]))
-        return actOut, potArr, massArr, dist
+        if(get_dist):
+         return actOut, potArr, massArr, dist
+        else:
+         return actOut, potArr, massArr
 
     @staticmethod
     def _term_in_action_sum(points,potential,masses=None):


### PR DESCRIPTION
A generalisation of the function action, which can now optionally return the distance along a path that is used in the calculation of the action. 

This was a great aid to us in benchmarking/bugfixing with respect to the consistency of the definition of collective degrees of freedom. 